### PR TITLE
ci: don't force bump patch version

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -77,7 +77,6 @@ func SemanticRelease(ctx context.Context, repo string, dry bool) error {
 	args := []string{
 		"--allow-initial-development-versions",
 		"--allow-no-changes",
-		"--force-bump-patch-version",
 		"--ci-condition=default",
 		"--provider=github",
 		"--provider-opt=slug=" + repo,


### PR DESCRIPTION
This is typically only used for services, not for libraries.
