### PR TITLE
fix: prevent binary release error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  goreleaser:
-    needs: [release]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Sage
-        uses: einride/sage/actions/setup@master
-        with:
-          go-version: 1.19
-
       - name: Run GoReleaser
         run: make go-releaser snapshot=false
         env:

--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -2,4 +2,4 @@ module sage
 
 go 1.19
 
-require go.einride.tech/sage v0.162.0
+require go.einride.tech/sage v0.164.1

--- a/.sage/go.sum
+++ b/.sage/go.sum
@@ -1,2 +1,2 @@
-go.einride.tech/sage v0.162.0 h1:4kfFBFh9jC7UbAs0E2cGKTWeMBrdW14RQ9xkdqIdgdc=
-go.einride.tech/sage v0.162.0/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=
+go.einride.tech/sage v0.164.1 h1:L4F4xazoZeSepzux6tuxg/OveaDvA5p5Qhb9MptVApU=
+go.einride.tech/sage v0.164.1/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=

--- a/.sage/main.go
+++ b/.sage/main.go
@@ -90,9 +90,16 @@ func SemanticRelease(ctx context.Context, repo string, dry bool) error {
 
 func GoReleaser(ctx context.Context, snapshot bool) error {
 	sg.Logger(ctx).Println("building Go binary releases...")
+	if err := sggit.Command(ctx, "fetch", "--force", "--tags").Run(); err != nil {
+		return err
+	}
 	args := []string{
 		"release",
 		"--rm-dist",
+	}
+	if len(sggit.Tags(ctx)) == 0 && !snapshot {
+		sg.Logger(ctx).Printf("no git tag found for %s, forcing snapshot mode", sggit.ShortSHA(ctx))
+		snapshot = true
 	}
 	if snapshot {
 		args = append(args, "--snapshot")


### PR DESCRIPTION
Force snapshot mode when no new tag is available to upload them to.
