### PR TITLE
feat(CCO-288): add reference id to wallet transaction

### DIFF
--- a/wallettransaction.go
+++ b/wallettransaction.go
@@ -58,6 +58,9 @@ type WalletTransaction struct {
 	// Reference type of this transaction.
 	ReferenceType string `json:"referenceType"`
 
+	// Reference id of this transaction.
+	ReferenceID string `json:"referenceId"`
+
 	// Transaction group of this transaction.
 	Group TransactionGroup `json:"group"`
 

--- a/wallettransaction_test.go
+++ b/wallettransaction_test.go
@@ -41,6 +41,7 @@ func TestWalletTransaction_MarshalJSON(t *testing.T) {
   "createdAt": "2022-04-22T09:47:05Z",
   "updatedAt": "2022-04-22T09:47:06Z",
   "referenceType": "SubscriptionPurchase",
+  "referenceId": "4908086",
   "group": "withdraw",
   "state": "complete",
   "note": "Test transaction."


### PR DESCRIPTION
This PR adds the referenceId to the wallet transaction. This field was added in a recent Monta release.