### PR TITLE
feat: add webhook types

### DIFF
--- a/unixtimestamp.go
+++ b/unixtimestamp.go
@@ -1,0 +1,20 @@
+package monta
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type UnixTimestamp struct {
+	time.Time
+}
+
+// Unmarshal a unix timestamp (in milliseconds) from a JSON object to a human readable timestamp.
+func (ut *UnixTimestamp) UnmarshalJSON(data []byte) error {
+	var timestamp int64
+	if err := json.Unmarshal(data, &timestamp); err != nil {
+		return err
+	}
+	ut.Time = time.Unix(timestamp/1000, 0)
+	return nil
+}

--- a/webhook.go
+++ b/webhook.go
@@ -1,0 +1,28 @@
+package monta
+
+// WebhookRequest is a webhook request from Monta.
+type WebhookRequest struct {
+	// List of webhook entries delivered in a batch.
+	Entries []WebhookEntry `json:"entries"`
+
+	// Number of pending events left for delivery.
+	Pending int64 `json:"pending"`
+
+	// Timestamp of the request (milliseconds from the epoch of 1970-01-01T00:00:00Z).
+	Timestamp UnixTimestamp `json:"timestamp"`
+}
+
+// WebhookEntry is an entry of the webhook request.
+type WebhookEntry struct {
+	// Type of the entity.
+	EntityType WebhookEntityType `json:"entityType"`
+
+	// ID of the entity.
+	EntityID string `json:"entityId"`
+
+	// Type of event, ie. created, deleted, updated.
+	EventType WebhookEventType `json:"eventType"`
+
+	// Payload of this entity, e.g. a full Charge object.
+	Payload interface{} `json:"payload"`
+}

--- a/webhookentitytype.go
+++ b/webhookentitytype.go
@@ -1,0 +1,12 @@
+package monta
+
+// WebhookEtityType represents the type of a webhook entity.
+type WebhookEntityType string
+
+// Known [WebhookEntityType] values.
+const (
+	WebhookEntityTypeCharge      WebhookEntityType = "charge"
+	WebhookEntityTypeChargePoint WebhookEntityType = "charge-point"
+	WebhookEntityTypeSite        WebhookEntityType = "site"
+	WebhookEntityTypeTeamMember  WebhookEntityType = "team-member"
+)

--- a/webhookeventtype.go
+++ b/webhookeventtype.go
@@ -1,0 +1,11 @@
+package monta
+
+// WebhookEventType represents the type of a webhook event.
+type WebhookEventType string
+
+// Known [WebhookEventType] values.
+const (
+	WebhookEventTypeCreated WebhookEventType = "created"
+	WebhookEventTypeDeleted WebhookEventType = "deleted"
+	WebhookEventTypeUpdated WebhookEventType = "updated"
+)


### PR DESCRIPTION
This PR introduces the Monta webhook type structs to be used with the GET, UPDATE, DELETE and RETRIEVE webhook endppoints.
