### PR TITLE
feat: implement get webhook config endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -58,6 +57,9 @@ type Client interface {
 		ctx context.Context,
 		request *ListTeamsRequest,
 	) (*ListTeamsResponse, error)
+
+	// Webhooks
+	GetWebhookConfig(ctx context.Context) (*GetWebhookConfigResponse, error)
 }
 
 // clientImpl to the Monta Partner API.
@@ -225,7 +227,7 @@ func execute[T any](
 	if httpResponse.StatusCode != http.StatusOK && httpResponse.StatusCode != http.StatusCreated {
 		return nil, newStatusError(httpResponse)
 	}
-	respBody, err := ioutil.ReadAll(httpResponse.Body)
+	respBody, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/client_webhooks.go
+++ b/client_webhooks.go
@@ -1,0 +1,23 @@
+package monta
+
+import (
+	"context"
+	"net/url"
+)
+
+// GetWebhookConfigResponse is the response output from the [Client.GetWebhookConfig] method.
+type GetWebhookConfigResponse struct {
+	// A HTTPS URL to send the webhook payload to when an event occurs.
+	WebhookURL string `json:"webhookUrl"`
+	// A cryptoghrapic secret used to sign the webhook payload.
+	WebhookSecret string `json:"webhookSecret"`
+	// A list of event types to subscribe to. Use of ["*"] means subscribe to all.
+	EventTypes []*WebhookEventType `json:"eventTypes"`
+}
+
+// GetWebhookConfig to get your webhook config.
+func (c *clientImpl) GetWebhookConfig(ctx context.Context) (*GetWebhookConfigResponse, error) {
+	path := "/v1/webhooks/config"
+	query := url.Values{}
+	return doGet[GetWebhookConfigResponse](ctx, c, path, query)
+}

--- a/scope.go
+++ b/scope.go
@@ -11,4 +11,5 @@ const (
 	ScopeChargeTransactions Scope = "charge-transactions"
 	ScopeWalletTransactions Scope = "wallet-transactions"
 	ScopeControlCharging    Scope = "control-charging"
+	ScopeManageWebhooks     Scope = "manage-webhooks"
 )


### PR DESCRIPTION
This PR implements the get webhook config endpoint.
https://docs.partner-api.monta.com/reference/get-webhook-config

#71 should be merged first.
