### PR TITLE
feat: implement update webhook config endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,6 +60,10 @@ type Client interface {
 
 	// Webhooks
 	GetWebhookConfig(ctx context.Context) (*GetWebhookConfigResponse, error)
+	UpdateWebhookConfig(
+		ctx context.Context,
+		request *UpdateWebhookConfigRequest,
+	) (*UpdateWebhookConfigResponse, error)
 }
 
 // clientImpl to the Monta Partner API.
@@ -183,6 +187,11 @@ func doPatch[T any](ctx context.Context, client *clientImpl, path string, body i
 func doDelete(ctx context.Context, client *clientImpl, path string) error {
 	_, err := execute[any](ctx, client, http.MethodDelete, path, nil, nil, nil)
 	return err
+}
+
+// Template method to execute PUT requests towards monta.
+func doPut[T any](ctx context.Context, client *clientImpl, path string, body io.Reader) (*T, error) {
+	return execute[T](ctx, client, http.MethodPut, path, nil, &http.Header{"content-type": {"application/json"}}, body)
 }
 
 // Template method to execute requests towards monta.

--- a/client_webhooks.go
+++ b/client_webhooks.go
@@ -1,7 +1,9 @@
 package monta
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/url"
 )
 
@@ -20,4 +22,37 @@ func (c *clientImpl) GetWebhookConfig(ctx context.Context) (*GetWebhookConfigRes
 	path := "/v1/webhooks/config"
 	query := url.Values{}
 	return doGet[GetWebhookConfigResponse](ctx, c, path, query)
+}
+
+// UpdateWebhookConfigRequest is the request input to the [Client.UpdateWebhookConfig] method.
+type UpdateWebhookConfigRequest struct {
+	// A HTTPS URL to send the webhook payload to when an event occurs.
+	WebhookURL string `json:"webhookUrl"`
+	// A cryptoghrapic secret used to sign the webhook payload.
+	WebhookSecret string `json:"webhookSecret"`
+	// A list of event type to subscribe to. Use ["*"] to subscribe to all.
+	EventTypes []*WebhookEventType `json:"eventTypes"`
+}
+
+// UpdateWebhookConfigResponse is the response output from the [Client.UpdateWebhookConfig] method.
+type UpdateWebhookConfigResponse struct {
+	// A HTTPS URL to send the webhook payload to when an event occurs.
+	WebhookURL string `json:"webhookUrl"`
+	// A cryptoghrapic secret used to sign the webhook payload.
+	WebhookSecret string `json:"webhookSecret"`
+	// A list of event type to subscribe to. Use of ["*"] means subscribe to all.
+	EventTypes []*string `json:"eventTypes"`
+}
+
+// UpdateWebhookConfig to update your webhook config.
+func (c *clientImpl) UpdateWebhookConfig(
+	ctx context.Context,
+	request *UpdateWebhookConfigRequest,
+) (*UpdateWebhookConfigResponse, error) {
+	path := "/v1/webhooks/config"
+	var requestBody bytes.Buffer
+	if err := json.NewEncoder(&requestBody).Encode(&request); err != nil {
+		return nil, err
+	}
+	return doPut[UpdateWebhookConfigResponse](ctx, c, path, &requestBody)
 }


### PR DESCRIPTION
This PR implements the update webhook config endpoint.
https://docs.partner-api.monta.com/reference/update-webhook-config

#72 needs to be merged first.
