### PR TITLE
feat: add ChargePointKw field to charge

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -85,6 +85,9 @@ type Charge struct {
 	// A note taken for this charge.
 	Note *string `json:"note"`
 
+	// The charge point KW recorded during the charge.
+	ChargePointKw *float64 `json:"chargePointKw"`
+
 	// Configured Kwh limit for this charge.
 	KWhLimit *float64 `json:"kwhLimit"`
 

--- a/charge_test.go
+++ b/charge_test.go
@@ -40,6 +40,7 @@ func TestCharge_MarshalJSON(t *testing.T) {
   "stopReason": "Some reason why the charge stopped.",
   "paymentMethod": "free",
   "note": "Lorem Ipsum",
+  "chargePointKw": 138.56,
   "kwhLimit": 21,
   "currency": {
     "identifier": "DKK",


### PR DESCRIPTION
This PR adds the field chargePointKW to charges/sessions. This was recently added to get insights into the delivered kW.