### PR TITLE
Add list webhook/entries endpoint in client

### DIFF
--- a/client.go
+++ b/client.go
@@ -65,6 +65,7 @@ type Client interface {
 		request *WebhookConfig,
 	) (*WebhookConfig, error)
 	DeleteWebhookConfig(ctx context.Context) error
+	ListWebhookEntries(ctx context.Context, request *ListWebhookEntriesRequest) (*ListWebhookEntriesResponse, error)
 }
 
 // clientImpl to the Monta Partner API.

--- a/client_webhooks.go
+++ b/client_webhooks.go
@@ -15,8 +15,8 @@ type WebhookConfig struct {
 	WebhookURL string `json:"webhookUrl"`
 	// A cryptoghrapic secret used to sign the webhook payload.
 	WebhookSecret string `json:"webhookSecret"`
-	// A list of event type to subscribe to. Use ["*"] to subscribe to all.
-	EventTypes []*WebhookEventType `json:"eventTypes"`
+	// List of entity types in plural to subscribe to. Use ["*"] to subscribe to all.
+	EventTypes []*WebhookEntityPluralType `json:"eventTypes"`
 }
 
 // GetWebhookConfig to get your webhook config.

--- a/client_webhooksentries.go
+++ b/client_webhooksentries.go
@@ -1,0 +1,34 @@
+package monta
+
+import (
+	"context"
+	"net/url"
+)
+
+const webhooksEntriesBasePath = "/v1/webhooks/entries"
+
+// ListWebhookEntriesRequest is the request for [Client.ListWebhookEntries] method.
+//
+// Status filter is not implemented due to undefined integer value mapping by docs at this moment in time.
+type ListWebhookEntriesRequest struct {
+	PageFilters
+}
+
+// ListWebhookEntriesResponse is the response for [Client.ListWebhookEntries] method.
+type ListWebhookEntriesResponse struct {
+	// List of webhook entries events for your consumer in the past 24 hours
+	Events []WebhookEvent `json:"data"`
+
+	// PageMeta with metadata about the current page.
+	PageMeta PageMeta `json:"meta"`
+}
+
+// ListWebhookEntries to list your webhook entries from the past 24 hours.
+func (c *clientImpl) ListWebhookEntries(
+	ctx context.Context,
+	request *ListWebhookEntriesRequest,
+) (*ListWebhookEntriesResponse, error) {
+	query := url.Values{}
+	request.PageFilters.Apply(query)
+	return doGet[ListWebhookEntriesResponse](ctx, c, webhooksEntriesBasePath, query)
+}

--- a/webhookentitypluraltype.go
+++ b/webhookentitypluraltype.go
@@ -1,0 +1,19 @@
+package monta
+
+// WebhookEntityPluralType represents the type of a webhook entity in plural form.
+type WebhookEntityPluralType string
+
+// Known [WebhookEntityPluralType] values.
+const (
+	WebhookEntityPluralTypeAll                WebhookEntityPluralType = "*"
+	WebhookEntityPluralTypeCharges            WebhookEntityPluralType = "charges"
+	WebhookEntityPluralTypeChargePoints       WebhookEntityPluralType = "charge-points"
+	WebhookEntityPluralTypeSites              WebhookEntityPluralType = "sites"
+	WebhookEntityPluralTypeTeams              WebhookEntityPluralType = "teams"
+	WebhookEntityPluralTypeTeamMembers        WebhookEntityPluralType = "team-members"
+	WebhookEntityPluralTypeInstallerJobs      WebhookEntityPluralType = "installer-jobs"
+	WebhookEntityPluralTypeWalletTransactions WebhookEntityPluralType = "wallet-transactions"
+	WebhookEntityPluralTypePriceGroups        WebhookEntityPluralType = "price-groups"
+	WebhookEntityPluralTypePlans              WebhookEntityPluralType = "plans"
+	WebhookEntityPluralTypeSubscriptions      WebhookEntityPluralType = "subscriptions"
+)

--- a/webhookentitytype.go
+++ b/webhookentitytype.go
@@ -5,8 +5,14 @@ type WebhookEntityType string
 
 // Known [WebhookEntityType] values.
 const (
-	WebhookEntityTypeCharge      WebhookEntityType = "charge"
-	WebhookEntityTypeChargePoint WebhookEntityType = "charge-point"
-	WebhookEntityTypeSite        WebhookEntityType = "site"
-	WebhookEntityTypeTeamMember  WebhookEntityType = "team-member"
+	WebhookEntityTypeCharge            WebhookEntityType = "charge"
+	WebhookEntityTypeChargePoint       WebhookEntityType = "charge-point"
+	WebhookEntityTypeSite              WebhookEntityType = "site"
+	WebhookEntityTypeTeamMember        WebhookEntityType = "team-member"
+	WebhookEntityPluralTypeTeam        WebhookEntityType = "team"
+	WebhookEntityTypeInstallerJob      WebhookEntityType = "installer-job"
+	WebhookEntityTypeWalletTransaction WebhookEntityType = "wallet-transaction"
+	WebhookEntityTypePriceGroup        WebhookEntityType = "price-group"
+	WebhookEntityTypePlan              WebhookEntityType = "plan"
+	WebhookEntityTypeSubscription      WebhookEntityType = "subscription"
 )

--- a/webhookevent.go
+++ b/webhookevent.go
@@ -1,0 +1,43 @@
+package monta
+
+import "time"
+
+// WebhookEvent wraps a WebhookEntry and metadata on a webhook call.
+type WebhookEvent struct {
+	// ID of the webhook event.
+	ID int64 `json:"id"`
+
+	// ConsumerID of the intended receiver of the webhook.
+	ConsumerID int64 `json:"consumerId"`
+
+	// ID of the operator.
+	OperatorID int64 `json:"operatorId"`
+
+	// Entity type related to webhook event.
+	WebhookEntityPluralType WebhookEntityPluralType `json:"eventType"`
+
+	// Payload of the related webhook call.
+	WebhookEntry WebhookEntry `json:"payload"`
+
+	// Status of the webhook call.
+	Status WebhookEventStatus `json:"status"`
+
+	// Error related to the webhook call.
+	Error string `json:"error"`
+
+	// When the webhook event was created.
+	CreatedAt time.Time `json:"createdAt"`
+
+	// When the webhook event was last updated.
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// Status of the webhook call.
+type WebhookEventStatus string
+
+// Known [WebhookEventStatus] values.
+const (
+	WebhookStatusPending   WebhookEventStatus = "pending"
+	WebhookStatusCompleted WebhookEventStatus = "completed"
+	WebhookStatusFailure   WebhookEventStatus = "failure"
+)

--- a/webhookevent_test.go
+++ b/webhookevent_test.go
@@ -1,0 +1,35 @@
+package monta
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestWebhookEvent_MarshalJSON(t *testing.T) {
+	expected := strings.TrimSpace(`
+{
+  "id": 1,
+  "consumerId": 1,
+  "operatorId": 1,
+  "eventType": "charges",
+  "payload": {
+    "entityType": "charge",
+    "entityId": "1",
+    "eventType": "updated",
+    "payload": {}
+  },
+  "status": "completed",
+  "error": "",
+  "createdAt": "2022-02-04T14:50:33Z",
+  "updatedAt": "2022-02-04T14:50:36Z"
+}
+`)
+	var webhookEvent WebhookEvent
+	assert.NilError(t, json.Unmarshal([]byte(expected), &webhookEvent))
+	actual, err := json.MarshalIndent(&webhookEvent, "", "  ")
+	assert.NilError(t, err)
+	assert.Equal(t, expected, string(actual))
+}


### PR DESCRIPTION
This pr adds support to call the list v1/webhook/entries endpoint from the Monta partner API. To support this it fixes also the use of a plural form of entity types as used in the other webhook endpoints. 


- fix(webhooks): use plural forms of entity types in webhook config endpoints
- feat(webhooks): add list webhook entries endpoint
