### PR TITLE
SECENG-718: add Security Policy to open source repos

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,41 @@
 # Security Policy
 
-## Supported Versions
+Einride welcomes feedback from security researchers and the general public to
+help improve our security. If you believe you have discovered a vulnerability,
+privacy issue, exposed data, or other security issues in relation to this
+project, we want to hear from you. This policy outlines steps for reporting
+security issues to us, what we expect, and what you can expect from us.
 
-We release patches for security vulnerabilities. This project is currently unstable (v0.x) and only the latest version will receive security patches.
+## Supported versions
 
-## Reporting a Vulnerability
+We release patches for security issues according to semantic versioning. This
+project is currently unstable (v0.x) and only the latest version will receive
+security patches.
 
-Please report (suspected) security vulnerabilities to **[oss-security@einride.tech](mailto:oss-security@einride.tech)**. You will receive a response from us within 2 business days. If the issue is confirmed, we will release a patch as soon as possible.
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities through public issues,
+discussions, or change requests.
+
+Please report security issues via [oss-security@einride.tech][email]. Provide
+all relevant information, including steps to reproduce the issue, any affected
+versions, and known mitigations. The more details you provide, the easier it
+will be for us to triage and fix the issue. You will receive a response from us
+within 2 business days. If the issue is confirmed, a patch will be released as
+soon as possible.
+
+For more information, or security issues not relating to open source code,
+please consult our [Vulnerability Disclosure Policy][vdp].
+
+## Preferred languages
+
+English is our preferred language of communication.
+
+## Contributions and recognition
+
+We appreciate every contribution and will do our best to publicly
+[acknowledge][acknowledgments] your contributions.
+
+[acknowledgments]: https://einride.tech/security-acknowledgments.txt
+[email]: mailto:oss-security@einride.tech
+[vdp]: https://www.einride.tech/vulnerability-disclosure-policy


### PR DESCRIPTION
Security has recently published a Vulnerability Disclosure Policy. Additionally,
we have developed a process and policy for handling security issues in our open 
source repositories. This pull request introduces the Security Policy.
