### PR TITLE
feat: add body field to status error

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,8 @@
 package monta
 
 import (
+	"fmt"
+	"io"
 	"net/http"
 )
 
@@ -8,16 +10,23 @@ import (
 type StatusError struct {
 	Status     string
 	StatusCode int
+	Body       string
 }
 
 func newStatusError(httpResponse *http.Response) error {
+	body, _ := io.ReadAll(httpResponse.Body)
+
 	return &StatusError{
 		Status:     httpResponse.Status,
 		StatusCode: httpResponse.StatusCode,
+		Body:       string(body),
 	}
 }
 
 // Error implements error.
 func (s *StatusError) Error() string {
+	if s.Body != "" {
+		return fmt.Sprintf("HTTP %d %s: %s", s.StatusCode, s.Status, s.Body)
+	}
 	return s.Status
 }


### PR DESCRIPTION
This PR adds a `Body` field to `StatusError` to simplify debugging for failed requests.