### PR TITLE
feat: add SKIP_GIT_VERIFY_NO_DIFF env var for github workflow checks

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -64,6 +64,10 @@ func ConvcoCheck(ctx context.Context) error {
 
 func GitVerifyNoDiff(ctx context.Context) error {
 	sg.Logger(ctx).Println("verifying that git has no diff...")
+	if os.Getenv("SKIP_GIT_VERIFY_NO_DIFF") == "true" {
+	    sg.Logger(ctx).Println("skipping git verification (SKIP_GIT_VERIFY_NO_DIFF is set)")
+	    return nil
+	}
 	return sggit.VerifyNoDiff(ctx)
 }
 


### PR DESCRIPTION
This change introduces an environment variable `SKIP_GIT_VERIFY_NO_DIFF` which, when set to `true`, allows skipping the git verification step. This will be useful to enable the automation of fixing failing dependabot PRs (which will becoming as a GitHub workflow in another PR).