### PR TITLE
  feat(client): retry idempotent GET requests on transient errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,6 +12,15 @@ import (
 
 const apiHost = "https://partner-api.monta.com/api"
 
+const (
+	// defaultMaxRetries is the number of retries performed for idempotent
+	// requests that fail with a transient error.
+	defaultMaxRetries = 3
+	// defaultRetryBaseDelay is the base delay used for exponential backoff
+	// between retries.
+	defaultRetryBaseDelay = 200 * time.Millisecond
+)
+
 type Client interface {
 	GetMe(ctx context.Context) (*Me, error)
 
@@ -110,6 +119,10 @@ func NewClient(options ...ClientOption) Client {
 	client := &clientImpl{
 		httpClient:     http.DefaultClient,
 		tokenSemaphore: make(chan struct{}, 1),
+		config: clientConfig{
+			maxRetries:     defaultMaxRetries,
+			retryBaseDelay: defaultRetryBaseDelay,
+		},
 	}
 	for _, option := range options {
 		option(&client.config)
@@ -120,9 +133,11 @@ func NewClient(options ...ClientOption) Client {
 }
 
 type clientConfig struct {
-	clientID     string
-	clientSecret string
-	token        *Token
+	clientID       string
+	clientSecret   string
+	token          *Token
+	maxRetries     int
+	retryBaseDelay time.Duration
 }
 
 // WithClientIDAndSecret configures authentication using the provided client ID and secret.
@@ -137,6 +152,17 @@ func WithClientIDAndSecret(clientID, clientSecret string) ClientOption {
 func WithToken(token *Token) ClientOption {
 	return func(config *clientConfig) {
 		config.token = token
+	}
+}
+
+// WithRetry configures automatic retries for idempotent (GET) requests that
+// fail with a transient error (a network error, or an HTTP 429 or 5xx
+// response). Retries use exponential backoff starting at baseDelay. Set
+// maxRetries to 0 to disable retries.
+func WithRetry(maxRetries int, baseDelay time.Duration) ClientOption {
+	return func(config *clientConfig) {
+		config.maxRetries = maxRetries
+		config.retryBaseDelay = baseDelay
 	}
 }
 
@@ -258,16 +284,13 @@ func execute[T any](
 	if err := client.setAuthorization(ctx, httpRequest); err != nil {
 		return nil, err
 	}
-	httpResponse, err := client.httpClient.Do(httpRequest)
+	httpResponse, err := client.doWithRetry(ctx, httpRequest, method)
 	if err != nil {
 		return nil, err
 	}
 	defer func() {
 		_ = httpResponse.Body.Close()
 	}()
-	if httpResponse.StatusCode != http.StatusOK && httpResponse.StatusCode != http.StatusCreated {
-		return nil, newStatusError(httpResponse)
-	}
 	respBody, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, err
@@ -277,4 +300,70 @@ func execute[T any](
 	}
 	var response T
 	return &response, json.Unmarshal(respBody, &response)
+}
+
+// doWithRetry executes the request, retrying idempotent (GET) requests that
+// fail with a transient error (a network error, or an HTTP 429 or 5xx
+// response). It returns a response with a status of 200 OK or 201 Created and
+// an open body, or an error. The bodies of failed responses are closed before
+// returning.
+func (c *clientImpl) doWithRetry(ctx context.Context, request *http.Request, method string) (*http.Response, error) {
+	retryable := method == http.MethodGet
+	var lastErr error
+	for attempt := 0; attempt <= c.config.maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := sleepWithBackoff(ctx, c.config.retryBaseDelay, attempt); err != nil {
+				return nil, err
+			}
+		}
+		httpResponse, err := c.httpClient.Do(request)
+		if err != nil {
+			lastErr = err
+			if retryable {
+				continue
+			}
+			return nil, err
+		}
+		if httpResponse.StatusCode == http.StatusOK || httpResponse.StatusCode == http.StatusCreated {
+			return httpResponse, nil
+		}
+		statusErr := newStatusError(httpResponse)
+		_ = httpResponse.Body.Close()
+		lastErr = statusErr
+		if retryable && retryableStatusCode(httpResponse.StatusCode) {
+			continue
+		}
+		return nil, statusErr
+	}
+	return nil, lastErr
+}
+
+// retryableStatusCode reports whether an HTTP status code represents a
+// transient failure that warrants a retry.
+func retryableStatusCode(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError
+}
+
+// sleepWithBackoff waits for an exponentially increasing delay based on the
+// attempt number, returning early if the context is cancelled.
+func sleepWithBackoff(ctx context.Context, baseDelay time.Duration, attempt int) error {
+	timer := time.NewTimer(backoffDelay(baseDelay, attempt))
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// backoffDelay returns the delay before the given (1-based) retry attempt,
+// doubling with each attempt while capping the exponent to avoid overflow.
+func backoffDelay(baseDelay time.Duration, attempt int) time.Duration {
+	const maxShift = 6
+	shift := attempt - 1
+	if shift > maxShift {
+		shift = maxShift
+	}
+	return baseDelay << shift
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,200 @@
+package monta
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+// roundTripFunc adapts a function to an [http.RoundTripper].
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func newTestResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     http.StatusText(statusCode),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func newTestClient(transport http.RoundTripper, maxRetries int) *clientImpl {
+	return &clientImpl{
+		httpClient: &http.Client{Transport: transport},
+		config: clientConfig{
+			maxRetries:     maxRetries,
+			retryBaseDelay: time.Millisecond,
+		},
+	}
+}
+
+func closeResponse(resp *http.Response) {
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+}
+
+func TestDoWithRetry_RetriesGETOn5xxThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	client := newTestClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		if calls.Add(1) <= 2 {
+			return newTestResponse(http.StatusInternalServerError, `{"message":"Read Timeout"}`), nil
+		}
+		return newTestResponse(http.StatusOK, `{}`), nil
+	}), 3)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiHost+"/foo", nil)
+	assert.NilError(t, err)
+	resp, err := client.doWithRetry(context.Background(), req, http.MethodGet)
+	defer closeResponse(resp)
+	assert.NilError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(3), calls.Load())
+}
+
+func TestDoWithRetry_RetriesGETOn429(t *testing.T) {
+	var calls atomic.Int32
+	client := newTestClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			return newTestResponse(http.StatusTooManyRequests, "slow down"), nil
+		}
+		return newTestResponse(http.StatusOK, `{}`), nil
+	}), 3)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiHost+"/foo", nil)
+	assert.NilError(t, err)
+	resp, err := client.doWithRetry(context.Background(), req, http.MethodGet)
+	defer closeResponse(resp)
+	assert.NilError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestDoWithRetry_ExhaustsRetriesAndReturnsStatusError(t *testing.T) {
+	var calls atomic.Int32
+	client := newTestClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return newTestResponse(http.StatusInternalServerError, "boom"), nil
+	}), 3)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiHost+"/foo", nil)
+	assert.NilError(t, err)
+	resp, err := client.doWithRetry(context.Background(), req, http.MethodGet)
+	defer closeResponse(resp)
+	var statusErr *StatusError
+	assert.Assert(t, errors.As(err, &statusErr))
+	assert.Equal(t, http.StatusInternalServerError, statusErr.StatusCode)
+	// 1 initial attempt + 3 retries.
+	assert.Equal(t, int32(4), calls.Load())
+}
+
+func TestDoWithRetry_DoesNotRetryNon5xx(t *testing.T) {
+	var calls atomic.Int32
+	client := newTestClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return newTestResponse(http.StatusNotFound, "not found"), nil
+	}), 3)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiHost+"/foo", nil)
+	assert.NilError(t, err)
+	resp, err := client.doWithRetry(context.Background(), req, http.MethodGet)
+	defer closeResponse(resp)
+	var statusErr *StatusError
+	assert.Assert(t, errors.As(err, &statusErr))
+	assert.Equal(t, http.StatusNotFound, statusErr.StatusCode)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestDoWithRetry_DoesNotRetryNonGET(t *testing.T) {
+	var calls atomic.Int32
+	client := newTestClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return newTestResponse(http.StatusInternalServerError, "boom"), nil
+	}), 3)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, apiHost+"/foo", nil)
+	assert.NilError(t, err)
+	resp, err := client.doWithRetry(context.Background(), req, http.MethodPost)
+	defer closeResponse(resp)
+	var statusErr *StatusError
+	assert.Assert(t, errors.As(err, &statusErr))
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestDoWithRetry_RetriesNetworkErrorOnGET(t *testing.T) {
+	var calls atomic.Int32
+	netErr := errors.New("connection reset")
+	client := newTestClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			return nil, netErr
+		}
+		return newTestResponse(http.StatusOK, `{}`), nil
+	}), 3)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiHost+"/foo", nil)
+	assert.NilError(t, err)
+	resp, err := client.doWithRetry(context.Background(), req, http.MethodGet)
+	defer closeResponse(resp)
+	assert.NilError(t, err)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestDoWithRetry_Disabled(t *testing.T) {
+	var calls atomic.Int32
+	client := newTestClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return newTestResponse(http.StatusInternalServerError, "boom"), nil
+	}), 0)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiHost+"/foo", nil)
+	assert.NilError(t, err)
+	resp, err := client.doWithRetry(context.Background(), req, http.MethodGet)
+	defer closeResponse(resp)
+	assert.Assert(t, err != nil)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestDoWithRetry_RespectsContextCancellation(t *testing.T) {
+	var calls atomic.Int32
+	client := newTestClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return newTestResponse(http.StatusInternalServerError, "boom"), nil
+	}), 5)
+	client.config.retryBaseDelay = time.Hour // force the backoff to block until cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiHost+"/foo", nil)
+	assert.NilError(t, err)
+	resp, err := client.doWithRetry(ctx, req, http.MethodGet)
+	defer closeResponse(resp)
+	assert.Assert(t, errors.Is(err, context.Canceled))
+	// One attempt before the (cancelled) backoff wait stops the loop.
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestBackoffDelay(t *testing.T) {
+	base := 100 * time.Millisecond
+	assert.Equal(t, base, backoffDelay(base, 1))
+	assert.Equal(t, 2*base, backoffDelay(base, 2))
+	assert.Equal(t, 4*base, backoffDelay(base, 3))
+	// Exponent is capped to avoid overflow on large attempt counts.
+	assert.Equal(t, 64*base, backoffDelay(base, 100))
+}
+
+func TestNewClient_RetryDefaults(t *testing.T) {
+	client, ok := NewClient().(*clientImpl)
+	assert.Assert(t, ok)
+	assert.Equal(t, defaultMaxRetries, client.config.maxRetries)
+	assert.Equal(t, defaultRetryBaseDelay, client.config.retryBaseDelay)
+}
+
+func TestWithRetry(t *testing.T) {
+	client, ok := NewClient(WithRetry(1, 5*time.Second)).(*clientImpl)
+	assert.Assert(t, ok)
+	assert.Equal(t, 1, client.config.maxRetries)
+	assert.Equal(t, 5*time.Second, client.config.retryBaseDelay)
+}


### PR DESCRIPTION
  Wrap HTTP calls in a retry loop that retries GET requests on network
  errors, HTTP 429, and 5xx responses using exponential backoff. Enabled
  by default (3 retries, 200ms base delay) and configurable via the new
  WithRetry option. Non-GET methods and non-transient status codes are
  not retried.
