### PR TITLE
chore(deps): consolidate dependabot updates into single multi-ecosystem PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,18 @@
 version: 2
 
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: "monthly"
+
 updates:
   - package-ecosystem: gomod
-    directory: .sage
-    schedule:
-      interval: "monthly"
-
-    cooldown:
-      default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
-      exclude:
-        - github.com/einride/*
-        - github.com/einride-autonomous/*
-        - github.com/einride-labs/*
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: "monthly"
-
-    cooldown:
-      default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
-      exclude:
-        - github.com/einride/*
-        - github.com/einride-autonomous/*
-        - github.com/einride-labs/*
-  - package-ecosystem: gomod
-    directory: cmd/monta
-    schedule:
-      interval: "monthly"
+    directories:
+      - .sage
+      - /
+      - cmd/monta
+    multi-ecosystem-group: "all-dependencies"
+    patterns: ["*"]
     cooldown:
       default-days: 7
       semver-major-days: 30


### PR DESCRIPTION
## Summary

Consolidates Dependabot updates into a **single PR** across all package ecosystems using GitHub's [multi-ecosystem groups](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-multi-ecosystem-updates) (GA) feature.

Previously Dependabot opened one PR per `gomod` directory (`.sage`, `/`, `cmd/monta`). Now all three roll up into one grouped PR via `multi-ecosystem-group: all-dependencies`.

## Changes

- Added top-level `multi-ecosystem-groups.all-dependencies` block carrying the monthly `schedule`.
- Collapsed the three identical `gomod` entries into one entry with a `directories` list.
- Moved `schedule` to the group; added required `multi-ecosystem-group` and `patterns: ["*"]` to the entry.
- Kept the `cooldown` (with einride excludes) per entry.

## Notes

- Config is only read from the **default branch**, so nothing changes until this merges.
- Existing per-ecosystem Dependabot PRs are closed automatically by GitHub once this lands and the next update runs.
- Trade-off: one failing/conflicting update now blocks the whole batch.