### PR TITLE
feat(VEH-4354): Add operatorRole paramter to charges

### DIFF
--- a/client_charges.go
+++ b/client_charges.go
@@ -41,6 +41,11 @@ type ListChargesRequest struct {
 
 	// Filter to retrieve charges where createdAt <= toDate.
 	ToDate *time.Time
+
+	// Filter to indicate the desired role to list charges. When omitted, the Monta API
+	// defaults to [OperatorRoleOwner]. [OperatorRoleOwner] returns charges from the
+	// operator's charge points, [OperatorRolePayer] returns charges paid by the operator.
+	OperatorRole *OperatorRole
 }
 
 // ListChargesResponse is the response output from the [Client.ListCharges] method.
@@ -98,6 +103,9 @@ func (c *clientImpl) ListCharges(ctx context.Context, request *ListChargesReques
 	}
 	if request.ToDate != nil {
 		query.Set("toDate", request.ToDate.UTC().Format(time.RFC3339))
+	}
+	if request.OperatorRole != nil {
+		query.Set("operatorRole", string(*request.OperatorRole))
 	}
 	return doGet[ListChargesResponse](ctx, c, path, query)
 }

--- a/client_charges_test.go
+++ b/client_charges_test.go
@@ -1,0 +1,54 @@
+package monta
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestListCharges_OperatorRole(t *testing.T) {
+	owner := OperatorRoleOwner
+	payer := OperatorRolePayer
+
+	testCases := []struct {
+		name         string
+		operatorRole *OperatorRole
+		wantParam    string
+	}{
+		{name: "omitted", operatorRole: nil},
+		{name: "owner", operatorRole: &owner, wantParam: "owner"},
+		{name: "payer", operatorRole: &payer, wantParam: "payer"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var gotQuery url.Values
+			client := NewClient(WithToken(&Token{
+				AccessToken:                "test-token",
+				AccessTokenExpirationTime:  time.Now().Add(time.Hour),
+				RefreshTokenExpirationTime: time.Now().Add(time.Hour),
+			})).(*clientImpl)
+			client.config.maxRetries = 0
+			client.httpClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				assert.Equal(t, "/api/v1/charges", r.URL.Path)
+				gotQuery = r.URL.Query()
+				return newTestResponse(http.StatusOK, `{"data":[],"meta":{}}`), nil
+			})}
+
+			_, err := client.ListCharges(context.Background(), &ListChargesRequest{
+				OperatorRole: testCase.operatorRole,
+			})
+			assert.NilError(t, err)
+
+			if testCase.wantParam == "" {
+				assert.Assert(t, !gotQuery.Has("operatorRole"))
+			} else {
+				assert.Equal(t, testCase.wantParam, gotQuery.Get("operatorRole"))
+			}
+		})
+	}
+}

--- a/operatorrole.go
+++ b/operatorrole.go
@@ -1,0 +1,12 @@
+package monta
+
+// OperatorRole enumerates filters for the operator's relationship to listed charges.
+type OperatorRole string
+
+// Known [OperatorRole] values.
+const (
+	// OperatorRoleOwner returns charges from charge points owned by the operator.
+	OperatorRoleOwner OperatorRole = "owner"
+	// OperatorRolePayer returns charges paid by the operator.
+	OperatorRolePayer OperatorRole = "payer"
+)


### PR DESCRIPTION
## Summary

This change adds `operatorRole` query parameter to `Charges`-related **list** endpoint. It is needed due to the necessity of calling `Monta API` with this parameter equal to `payer` to properly obtain EV Edison charges.

## References

[VEH-4354 Ticket in JIRA](https://einride.atlassian.net/browse/VEH-4354)